### PR TITLE
Migrate old preferences to new format and location

### DIFF
--- a/service/src/main/kotlin/org/microg/nlp/service/AbstractBackendHelper.kt
+++ b/service/src/main/kotlin/org/microg/nlp/service/AbstractBackendHelper.kt
@@ -67,7 +67,7 @@ abstract class AbstractBackendHelper(private val TAG: String, private val contex
                 Log.w(TAG, "Intent is not properly resolved, can't verify signature. Aborting.")
                 return
             }
-            val computedDigest = firstSignatureDigest(context, serviceIntent.getPackage(), if (signatureDigest?.length == 40) "SHA-1" else "SHA-256")
+            val computedDigest = firstSignatureDigest(context, serviceIntent.getPackage(), "SHA-256")
             if (signatureDigest != null && signatureDigest != computedDigest) {
                 Log.w(TAG, "Target signature does not match selected package ($signatureDigest != $computedDigest). Aborting.")
                 return


### PR DESCRIPTION
* Migrates the prefs from com.google.android.gms_preferences.xml
  to unified_nlp.xml
* Replaces the SHA-1 with matching SHA-256, since the UI
  code only supports SHA-256
* Removes SHA-1 support from AbstractBackendHelper,
  assuming that all old packages have migrated, and
  since they weren't fully working anyway.

Closes: #195 
Change-Id: I532883dc2fe1c71b001dc34bb9e6bef93d8681f2